### PR TITLE
Fix for 'none.json' requests

### DIFF
--- a/comparisontool/static/comparisontool/js/comparison-tool.js
+++ b/comparisontool/static/comparisontool/js/comparison-tool.js
@@ -2120,23 +2120,28 @@ var CFPBComparisonTool = (function() {
                     json_schools[key] = data;                        
                 });
                 json_schools = JSON.stringify( json_schools );
-                var request = $.ajax({
-                    type: "POST",
-                    url: posturl,
-                    dataType: "JSON",
-                    data: json_schools
-                });
-                request.done( function ( result ) {
 
-                });
-                request.fail( function ( xmlHttpRequest, textStatus ) {
-                    var foo = "";
-                    $.each(xmlHttpRequest, function(i, v) {
-                        foo += " " + i + ":" + v;
-                    });
-                    // alert( "Save failed!");
-                    $("#save-container").append( "Save failed!" + foo + " " + textStatus);
-                });
+                if ( global.worksheet_id !== "none") {
+                  var request = $.ajax({
+                      type: "POST",
+                      url: posturl,
+                      dataType: "JSON",
+                      data: json_schools
+                  });
+                  request.done( function ( result ) {
+
+                  });
+                  request.fail( function ( xmlHttpRequest, textStatus ) {
+                      var foo = "";
+                      $.each(xmlHttpRequest, function(i, v) {
+                          foo += " " + i + ":" + v;
+                      });
+                      // alert( "Save failed!");
+                      $("#save-container").append( "Save failed!" + foo + " " + textStatus);
+                  });
+                } else {
+                  $("#save-container").append( "Save failed! (invalid worksheet id)" );
+                }
                 var geturl = "http://" + document.location.host
                             + "/paying-for-college/compare-financial-aid-and-college-cost/"
                             + "#"


### PR DESCRIPTION
This PR puts in a check  before the API makes calls to the /worksheet/ endpoint.

This should prevent errors from occurring when the script requests 'none.json' from the API endpoint.

## Testing
- Having a running instance of `cfgov-refresh`
- Clone this repo
- From inside `cfgov-refresh`, use `pip install -e /path/to/django-college-costs-comparison`
- Load http://127.0.0.1:8000/paying-for-college/compare-financial-aid-and-college-cost/
- Add a school, change some fields, add some things to the Money for School section
- Back at the top, "Save Your Work"
- Copy the URL in the save modal, open it in a new window

If your data was saved properly, then everything is working!