### PR TITLE
Fix for og:titles error on templates

### DIFF
--- a/comparisontool/templates/comparisontool/choose_a_loan.html
+++ b/comparisontool/templates/comparisontool/choose_a_loan.html
@@ -5,7 +5,7 @@
 
 {% block page_meta %}
 <meta charset="UTF-8" />
-<meta property="og:title" content="{{% block title %}{% endblock %} &gt; Consumer Financial Protection Bureau"/>
+<meta property="og:title" content="Choose a student loan | Consumer Financial Protection Bureau"/>
 <meta property="og:url" content="{{ URL }}"/>
 <meta name="description" content="Comparing your options helps you find the loan best suited for your needs."/>
 

--- a/comparisontool/templates/comparisontool/landing.html
+++ b/comparisontool/templates/comparisontool/landing.html
@@ -5,7 +5,7 @@
 
 {% block page_meta %}
 <meta charset="UTF-8" />
-<meta property="og:title" content="{% block title %}{% endblock %} &gt; Consumer Financial Protection Bureau"/>
+<meta property="og:title" content="Paying for College | Consumer Financial Protection Bureau"/>
 <meta property="og:url" content="{{ URL }}"/>
 <meta name="description" content="Whether you’re enrolling in college soon, are a current student, or already have student loans, our resources can help you make the best decisions for you."/>
 

--- a/comparisontool/templates/comparisontool/manage_your_money.html
+++ b/comparisontool/templates/comparisontool/manage_your_money.html
@@ -5,7 +5,7 @@
 
 {% block page_meta %}
 <meta charset="UTF-8" />
-<meta property="og:title" content="{% block title %}{% endblock %} &gt; Consumer Financial Protection Bureau"/>
+<meta property="og:title" content="Manage college money | Consumer Financial Protection Bureau"/>
 <meta property="og:url" content="{{ URL }}"/>
 <meta name="description" content="Signing up for a bank account early can save you headaches later, and researching accounts with the lowest fees can help save you money."/>
 

--- a/comparisontool/templates/comparisontool/repay_student_debt.html
+++ b/comparisontool/templates/comparisontool/repay_student_debt.html
@@ -5,7 +5,7 @@
 
 {% block page_meta %}
 <meta charset="UTF-8" />
-<meta property="og:title" content="{% block title %}{% endblock %} &gt; Consumer Financial Protection Bureau"/>
+<meta property="og:title" content="Repay Student Debt | Consumer Financial Protection Bureau"/>
 <meta property="og:url" content="{{ URL }}"/>
 <meta name="description" content="This tool provides information and advice for optimizing how you pay off your student loans based on some basic information about your financial situation."/>
 

--- a/comparisontool/templates/comparisontool/technote.html
+++ b/comparisontool/templates/comparisontool/technote.html
@@ -5,7 +5,7 @@
 
 {% block page_meta %}
 <meta charset="UTF-8" />
-<meta property="og:title" content="{% block title %}{% endblock %} &gt; Consumer Financial Protection Bureau"/>
+<meta property="og:title" content="Paying for College Cost Comparison Tool | Consumer Financial Protection Bureau"/>
 <meta property="og:url" content="{{ URL }}"/>
 <meta name="description" content="Comparing your options helps you find the loan best suited for your needs."/>
 

--- a/comparisontool/templates/comparisontool/worksheet.html
+++ b/comparisontool/templates/comparisontool/worksheet.html
@@ -2,12 +2,11 @@
 
 {% load static from staticfiles %}
 
-
 {% block title %}Compare financial aid and college cost{% endblock %}
 
 {% block page_meta %}
 <meta charset="UTF-8" />
-<meta property="og:title" content="{% block title %}{% endblock %} &gt; Consumer Financial Protection Bureau"/>
+<meta property="og:title" content="Compare financial aid and college cost | Consumer Financial Protection Bureau"/>
 <meta property="og:url" content="{{ request.build_absolute_uri }}"/>
 <meta name="description" content="Use this tool to compare college costs and financial aid offers to see the financial impact you’ll face down the road. You can compare up to three schools at once."/>
 


### PR DESCRIPTION
Fix for og:titles error on templates

# Testing
Having a running instance of cfgov-refresh
Clone this repo
From inside cfgov-refresh, use pip install -e /path/to/django-college-costs-comparison
Load http://127.0.0.1:8000/paying-for-college/compare-financial-aid-and-college-cost/
View Source
Verify that the templates have the same title / og:title.