### PR TITLE
[hold] Add Django 1.11 compatibility

### DIFF
--- a/comparisontool/management/commands/load_bah.py
+++ b/comparisontool/management/commands/load_bah.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from glob import glob
 from json import dumps
 import csv
@@ -18,7 +16,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         path_spec = options['path_spec']
         for path in glob(path_spec):
-            print("loading BAH file:", path)
+            self.stdout.write("loading BAH file:" + path)
             with open(path) as csv_file:
                 reader = csv.DictReader(csv_file)
                 BAHRate.objects.all().delete()

--- a/comparisontool/management/commands/load_bah.py
+++ b/comparisontool/management/commands/load_bah.py
@@ -1,8 +1,7 @@
 from glob import glob
-from json import dumps
 import csv
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from comparisontool.models import *
 

--- a/comparisontool/management/commands/load_bah.py
+++ b/comparisontool/management/commands/load_bah.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from glob import glob
 from json import dumps
 import csv
@@ -8,16 +10,18 @@ from comparisontool.models import *
 
 
 class Command(BaseCommand):
-    args = '<path>'
     help = 'Load the specified CSV into the BAH database'
 
+    def add_arguments(self, parser):
+        parser.add_argument('path_spec')
+
     def handle(self, *args, **options):
-        for path_spec in args:
-            for path in glob(path_spec):
-                print "loading %s" % path
-                with open(path) as csv_file:
-                    reader = csv.DictReader(csv_file)
-                    BAHRate.objects.all().delete()
-                    for record in reader:
-                        new_rate = BAHRate(zip5=record['ZIP'], value=record['BAH'])
-                        new_rate.save()
+        path_spec = options['path_spec']
+        for path in glob(path_spec):
+            print("loading BAH file:", path)
+            with open(path) as csv_file:
+                reader = csv.DictReader(csv_file)
+                BAHRate.objects.all().delete()
+                for record in reader:
+                    new_rate = BAHRate(zip5=record['ZIP'], value=record['BAH'])
+                    new_rate.save()

--- a/comparisontool/management/commands/load_school.py
+++ b/comparisontool/management/commands/load_school.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from glob import glob
 from json import dumps
 import csv
@@ -8,36 +10,41 @@ from comparisontool.models import *
 
 
 class Command(BaseCommand):
-    args = '<path>'
     help = 'Load the specified CSV into the schools database'
 
+    def add_arguments(self, parser):
+        parser.add_argument('path_spec')
+
     def handle(self, *args, **options):
-        for path_spec in args:
-            for path in glob(path_spec):
-                print "loading %s" % path
-                with open(path) as csv_file:
-                    reader = csv.DictReader(csv_file)
-                    for record in reader:
-                        # Last load took 14 minutes, this will add a visual indicator that smth is happening
-                        print record['SCHOOL_ID']
-                        aliases = set()
-                        primary_school_name = record.get("SCHOOL")
-                        aliases.add(primary_school_name)
-                        aliases_packed = record.get('ALIAS')  # pipe delimited
-                        if aliases_packed:
-                            aliases = aliases.union(aliases_packed.split('|'))
-                        city = record.get('CITY')
-                        state = record.get('STATE')
-                        school_id = int(record['SCHOOL_ID'])
-                        data_json = dumps(record)
-                        school = School(school_id=school_id,
-                                        city=city,
-                                        state=state,
-                                        data_json=data_json)
-                        school.save()
-                        school.alias_set.all().delete()
-                        for (index, alias_str) in enumerate(aliases):
-                            alias = Alias(institution=school,
-                                          alias=alias_str,
-                                          is_primary=(alias_str == primary_school_name))
-                            alias.save()
+        path_spec = options['path_spec']
+        for path in glob(path_spec):
+            print("loading schools:", path)
+            with open(path) as csv_file:
+                reader = csv.DictReader(csv_file)
+                print("Schools loaded: ", end="")
+                for record in reader:
+                    # Last load took 14 minutes, this will add a visual indicator
+                    #  that something is happening
+                    print(record['SCHOOL_ID'], end=", ")
+                    aliases = set()
+                    primary_school_name = record.get("SCHOOL")
+                    aliases.add(primary_school_name)
+                    aliases_packed = record.get('ALIAS')  # pipe delimited
+                    if aliases_packed:
+                        aliases = aliases.union(aliases_packed.split('|'))
+                    city = record.get('CITY')
+                    state = record.get('STATE')
+                    school_id = int(record['SCHOOL_ID'])
+                    data_json = dumps(record)
+                    school = School(school_id=school_id,
+                            city=city,
+                            state=state,
+                            data_json=data_json)
+                    school.save()
+                    school.alias_set.all().delete()
+                    for (index, alias_str) in enumerate(aliases):
+                        alias = Alias(institution=school,
+                                alias=alias_str,
+                                is_primary=(alias_str == primary_school_name))
+                        alias.save()
+                print("... done!")

--- a/comparisontool/management/commands/load_school.py
+++ b/comparisontool/management/commands/load_school.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from glob import glob
 from json import dumps
 import csv
@@ -18,14 +16,14 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         path_spec = options['path_spec']
         for path in glob(path_spec):
-            print("loading schools:", path)
+            self.stdout.write("loading schools:" + path)
             with open(path) as csv_file:
                 reader = csv.DictReader(csv_file)
-                print("Schools loaded: ", end="")
+                self.stdout.write("Schools loaded: ", ending="")
                 for record in reader:
                     # Last load took 14 minutes, this will add a visual indicator
                     #  that something is happening
-                    print(record['SCHOOL_ID'], end=", ")
+                    self.stdout.write(record['SCHOOL_ID'], ending=", ")
                     aliases = set()
                     primary_school_name = record.get("SCHOOL")
                     aliases.add(primary_school_name)
@@ -47,4 +45,4 @@ class Command(BaseCommand):
                                 alias=alias_str,
                                 is_primary=(alias_str == primary_school_name))
                         alias.save()
-                print("... done!")
+                self.stdout.write("... done!")

--- a/comparisontool/management/commands/load_school.py
+++ b/comparisontool/management/commands/load_school.py
@@ -2,7 +2,7 @@ from glob import glob
 from json import dumps
 import csv
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from comparisontool.models import *
 

--- a/comparisontool/templates/comparisontool/feedback_thanks.html
+++ b/comparisontool/templates/comparisontool/feedback_thanks.html
@@ -1,4 +1,4 @@
-{% extends "front/base_nonresponsive.html" %} 
+{% extends "front/base_nonresponsive.html" %}
 {% load static from staticfiles %}
 
 {% block title %}Paying for College - Compare financial aid and college cost{% endblock %}
@@ -14,15 +14,15 @@
 
 {% block body_class %}page paying-for-college{% endblock %}
 
-{% block content %}     
-<div id="comparison-tool" class="comparison-tool sub-page-wrapper">     
+{% block content %}
+<div id="comparison-tool" class="comparison-tool sub-page-wrapper">
     <header id="comparison-tool-header" class="feedback-header">
         <a class="noStyles" href="/paying-for-college/">
             <h1>Paying for College</h1>
         </a>
-        <span>Compare financial aid and college cost</span>             
+        <span>Compare financial aid and college cost</span>
     </header><!-- end #comparison-tool-header -->
-    
+
     <section class="feedback-section clearfix">
         <div class="col col7 suf5">
             <hr>
@@ -41,7 +41,7 @@
                     </fieldset>
                 </form>
             </div>
-        </div>      
-    </section><!-- end .feedback-section -->            
+        </div>
+    </section><!-- end .feedback-section -->
 </div><!-- end #comparison-tool .comparison-tool -->
 {% endblock content %}

--- a/comparisontool/views.py
+++ b/comparisontool/views.py
@@ -22,7 +22,7 @@ class WorksheetJsonValidationError(Exception):
 
 
 class FeedbackView(TemplateView):
-    template_name = "comparisontool/feedback.html"
+    template_name = 'comparisontool/feedback.html'
 
     @property
     def form(self):
@@ -40,7 +40,7 @@ class FeedbackView(TemplateView):
         if form.is_valid():
             feedback = Feedback(message=form.cleaned_data['message'])
             feedback.save()
-            return render(request, "comparisontool/feedback_thanks.html")
+            return render(request, 'comparisontool/feedback_thanks.html')
 
         else:
             return HttpResponseBadRequest('bad request')
@@ -50,7 +50,7 @@ class BuildComparisonView(View):
 
     def get(self, request):
         return render(request, 'comparisontool/worksheet.html',
-                      {'data_js': "0"})
+                      {'data_js': '0'})
 
 
 class SchoolRepresentation(View):
@@ -71,7 +71,7 @@ class EmailLink(View):
             worksheet_guid = form.cleaned_data['id']
             worksheet = Worksheet.objects.get(guid=worksheet_guid)
             recipient = form.cleaned_data['email']
-            subject = "Your Personalized College Financial Aid Information"
+            subject = 'Your Personalized College Financial Aid Information'
             body_template = get_template('comparisontool/email_body.txt')
             context = {'guid': worksheet.guid}
             body = body_template.render(context, request)
@@ -160,7 +160,7 @@ class DataStorageView(View):
             else:
                 for fieldname in data[index].keys():
                     if fieldname not in allowed_fields:
-                        raise WorksheetJsonValidationError("field: %s"
+                        raise WorksheetJsonValidationError('field: %s'
                                                            % fieldname)
 
     def post(self, request, guid):

--- a/comparisontool/views.py
+++ b/comparisontool/views.py
@@ -4,7 +4,7 @@ import uuid
 
 from django.core.urlresolvers import reverse
 from django.views.generic import View, TemplateView
-from django.shortcuts import get_object_or_404, render_to_response
+from django.shortcuts import get_object_or_404, render
 from django.core.mail import send_mail
 from django.template import RequestContext
 from django.template.loader import get_template
@@ -40,9 +40,8 @@ class FeedbackView(TemplateView):
         if form.is_valid():
             feedback = Feedback(message=form.cleaned_data['message'])
             feedback.save()
-            return render_to_response("comparisontool/feedback_thanks.html",
-                                      locals(),
-                                      context_instance=RequestContext(request))
+            return render(request, "comparisontool/feedback_thanks.html")
+
         else:
             return HttpResponseBadRequest('bad request')
 
@@ -50,9 +49,8 @@ class FeedbackView(TemplateView):
 class BuildComparisonView(View):
 
     def get(self, request):
-        return render_to_response('comparisontool/worksheet.html',
-                                  {'data_js': "0"},
-                                  context_instance=RequestContext(request))
+        return render(request, 'comparisontool/worksheet.html',
+                      {'data_js': "0"})
 
 
 class SchoolRepresentation(View):
@@ -75,8 +73,8 @@ class EmailLink(View):
             recipient = form.cleaned_data['email']
             subject = "Your Personalized College Financial Aid Information"
             body_template = get_template('comparisontool/email_body.txt')
-            body = body_template.render(RequestContext(request,
-                                        dict(guid=worksheet.guid)))
+            context = {'guid': worksheet.guid}
+            body = body_template.render(context, request)
 
             send_mail(subject, body, 'no-reply-cfgov@cfpb.gov', [recipient],
                       fail_silently=False)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         'dj-database-url==0.4.2',
         'Django>=1.8,<1.12',
-        'django-haystack==2.6.0',
+        'django-haystack==2.7.0',
         'django-localflavor==1.1',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 usedevelop=True
 
-envlist=dj{18}-{sqlite,postgres}
+envlist=dj{18,111}-{sqlite,postgres}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -12,6 +12,7 @@ deps=
     coverage==4.2
 
     dj18: Django>=1.8,<1.9
+    dj111: Django>=1.11,<1.12
     postgres: psycopg2>=2.7
 
 setenv=


### PR DESCRIPTION
- Updates `views.py` to use `render()` method, which is preferred in Django 1.9+
- Removes trailing whitespace
- Updates django-admin commands to use updated `add_arguments` strategy
- Updates all instances of `print` to be a function (rather than a statement) for Python3 compatibility.

TODO:
- [x] This PR depends on #8. Once that one is merged, I'll update this one to make the diff more sensible.
- [x] Smoke test the changes when running this app inside of cf.gov
