### PR TITLE
Add rel noopener to PDF links

### DIFF
--- a/comparisontool/templates/comparisontool/choose_a_loan.html
+++ b/comparisontool/templates/comparisontool/choose_a_loan.html
@@ -174,7 +174,7 @@
 		<li class="li-2">Explore all your federal loan options first.</li>
 		<li class="li-3">Shop around if your aid package doesn't cover the full cost of college.</li>
 	</ol>
-	<a class="btn btn-document" target='_blank' href="/f/loan.pdf">Download <br/>action guide</a>
+	<a class="btn btn-document" target="_blank" rel="noopener noreferrer" href="/f/loan.pdf">Download <br/>action guide</a>
 </div>
 		</div>
 	</div>
@@ -574,7 +574,7 @@ If you are having trouble filling out the form, <a class="exit-link" href="http:
 </div>
 		</div>
 		<div class='span3'>
-			<a class="btn btn-document" href='/f/loan.pdf' target='_blank'>
+			<a class="btn btn-document" href="/f/loan.pdf" target="_blank" rel="noopener noreferrer">
     Download <br>action guide
 </a>
 		</div>

--- a/comparisontool/templates/comparisontool/choose_a_loan.html
+++ b/comparisontool/templates/comparisontool/choose_a_loan.html
@@ -174,7 +174,7 @@
 		<li class="li-2">Explore all your federal loan options first.</li>
 		<li class="li-3">Shop around if your aid package doesn't cover the full cost of college.</li>
 	</ol>
-	<a class="btn btn-document" target="_blank" rel="noopener noreferrer" href="/f/loan.pdf">Download <br/>action guide</a>
+	<a class="btn btn-document" target="_blank" rel="noopener noreferrer" href="/f/loan.pdf">Download <br>action guide</a>
 </div>
 		</div>
 	</div>


### PR DESCRIPTION
- Adds `rel="nopener noreferrer"` to two PDF links that were missing that with `target="_blank"` (reported by @lfatty).
- Normalizes quotes.