### PR TITLE
Fix the spritemap arrows

### DIFF
--- a/comparisontool/static/comparisontool/css/comparison-tool.css
+++ b/comparisontool/static/comparisontool/css/comparison-tool.css
@@ -932,6 +932,11 @@ This contains the majority of the structural styles for table-based elements.
 .grants .h5, .federal .h5, .private .h5, .contributions .h5 {
     font-size: 1.125em;
     font-weight: 600;
+    margin: 0;
+    text-transform: none;
+    padding: 0;
+    border: 0;
+    line-height: 1.5;
 }
 
 .grants h6, .federal h6, .private h6, .contributions h6 {

--- a/comparisontool/static/comparisontool/css/comparison-tool.css
+++ b/comparisontool/static/comparisontool/css/comparison-tool.css
@@ -916,6 +916,10 @@ This contains the majority of the structural styles for table-based elements.
     font-weight: 700;
 }
 
+#comparison-tables .h3 {
+    font-size: .8125em;
+}
+
 /* Accordion elements, not the instrument, sadly */
 .grants th, .grants td {
     border-bottom: 5px solid #0072ce;

--- a/comparisontool/static/comparisontool/css/comparison-tool.css
+++ b/comparisontool/static/comparisontool/css/comparison-tool.css
@@ -941,6 +941,7 @@ This contains the majority of the structural styles for table-based elements.
     padding: 0;
     border: 0;
     line-height: 1.5;
+    letter-spacing: 0;
 }
 
 .grants h6, .federal h6, .private h6, .contributions h6 {


### PR DESCRIPTION
The arrows which appear next to various headers to indicate the ability to expand sections of the site have been broken for some time. This was due to styles cascading into existing styles and changing a variety of spacing, font-size, and line-height declarations.

This fixes issue #14 .

## Changes
- Add specific CSS to the various H5 rules to restore the original style of the elements, fixing the spritemap arrows issue.
- Fix h3 font-size, restoring original size

## Notes
This does not fix the site to match current design standards, it simply restores styles to their original intended design to fix visual issues that occur.

# Screenshots
## Before:
<img width="299" alt="screen shot 2018-06-29 at 11 00 21 am" src="https://user-images.githubusercontent.com/1490703/42100259-bd60df82-7b8d-11e8-8d34-fd1147e175e5.png">

## After
<img width="455" alt="screen shot 2018-06-29 at 11 14 30 am" src="https://user-images.githubusercontent.com/1490703/42100297-d09671e8-7b8d-11e8-9723-db244b051fe8.png">
