### PR TITLE
Allow flexible library versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     classifiers=[
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Intended Audience :: Developers',
-        'Programming Language :: Python',      
+        'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Framework :: Django',
@@ -37,9 +37,9 @@ setup(
     zip_safe=False,
     setup_requires=['setuptools-git-version'],
     install_requires=[
-        'dj-database-url==0.4.2',
+        'dj-database-url>=0.4.2,<1',
         'Django>=1.8,<1.12',
-        'django-haystack==2.7.0',
-        'django-localflavor==1.1',
+        'django-haystack==2.7.0',  # Latest version that supports both Django 1.8 and 1.11
+        'django-localflavor>=1.1,<2',
     ]
 )


### PR DESCRIPTION
For most libraries, allow any revision within a major version. Ensure
that the set of allowed versions contains the actual version that
cfgov-refresh is currently on, so when we import and install this repo
in cfgov, it doesn't cause version conflicts.

Also, delete trailing whitespace.