### PR TITLE
Remove Django 1.8 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ setup(
     setup_requires=['setuptools-git-version'],
     install_requires=[
         'dj-database-url>=0.4.2,<1',
-        'Django>=1.8,<1.12',
-        'django-haystack==2.7.0',  # Latest version that supports both Django 1.8 and 1.11
+        'Django>=1.11,<1.12',
+        'django-haystack>=2.7,<2.9',
         'django-localflavor>=1.1,<2',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 usedevelop=True
 
-envlist=dj{18,111}-{sqlite,postgres}
+envlist=dj{111}-{sqlite,postgres}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -10,8 +10,6 @@ commands=coverage run ./manage.py test
 
 deps=
     coverage==4.2
-
-    dj18: Django>=1.8,<1.9
     dj111: Django>=1.11,<1.12
     postgres: psycopg2>=2.7
 


### PR DESCRIPTION
- Update `setup.py` and `tox.ini` to reflect that we don't support Django 1.8
- Allow flexible version for django-haystack