### PR TITLE
Fixes 500 on invalid post to DataStorageView

### DIFF
--- a/comparisontool/tests/test_views.py
+++ b/comparisontool/tests/test_views.py
@@ -60,6 +60,10 @@ class DataStorageViewTests(TestCase):
         response = self.client.get(self.path('1234'))
         self.assertEqual(response.status_code, 405)
 
+    def test_post_to_nonexistent_worksheet_returns_404(self):
+        response = self.client.post(self.path('invalid'))
+        self.assertEqual(response.status_code, 404)
+
     def test_post_with_no_body_returns_current_worksheet(self):
         # This test can't use the Django test client because it's not possible
         # to do a POST without a body that way.

--- a/comparisontool/views.py
+++ b/comparisontool/views.py
@@ -164,9 +164,8 @@ class DataStorageView(View):
                                                            % fieldname)
 
     def post(self, request, guid):
-        worksheet = Worksheet.objects.get(
-            guid=guid,
-        )
+        worksheet = get_object_or_404(Worksheet, guid=guid)
+
         if request.body:
             self.validate_json(request.body)
             worksheet.saved_data = request.body


### PR DESCRIPTION
Currently POSTs to the DataStorageView (that saves progress to a worksheet) that contain an invalid ID will cause a 500 error, e.g.

`compare-financial-aid-and-college-costs/api/worksheet/invalid.json`

This produces the following error:

> DoesNotExist: Worksheet matching query does not exist

This PR handles the case of an invalid worksheet ID and instead returns a 404 to the frontend. This should never happen during normal usage of the tool, but prevents 500s due to crawlers or maliciously crafted URLs.