### PR TITLE
Add Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 python:
 - 2.7
 - 3.6
-install: pip install tox
+install: 
+- pip install tox-travis
+- pip install tox
 before_script: psql -c 'create database dccc;' -U postgres
 script:
 - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
-- '2.7'
+- 2.7
+- 3.6
 install: pip install tox
 before_script: psql -c 'create database dccc;' -U postgres
 script:

--- a/comparisontool/management/commands/load_bah.py
+++ b/comparisontool/management/commands/load_bah.py
@@ -1,9 +1,9 @@
-from glob import glob
 import csv
+from glob import glob
 
 from django.core.management.base import BaseCommand
 
-from comparisontool.models import *
+from comparisontool.models import BAHRate
 
 
 class Command(BaseCommand):

--- a/comparisontool/management/commands/load_school.py
+++ b/comparisontool/management/commands/load_school.py
@@ -1,10 +1,10 @@
+import csv
 from glob import glob
 from json import dumps
-import csv
 
 from django.core.management.base import BaseCommand
 
-from comparisontool.models import *
+from comparisontool.models import Alias, School
 
 
 class Command(BaseCommand):
@@ -21,8 +21,8 @@ class Command(BaseCommand):
                 reader = csv.DictReader(csv_file)
                 self.stdout.write("Schools loaded: ", ending="")
                 for record in reader:
-                    # Last load took 14 minutes, this will add a visual indicator
-                    #  that something is happening
+                    # Last load took 14 minutes, this will add a visual
+                    # indicator that something is happening
                     self.stdout.write(record['SCHOOL_ID'], ending=", ")
                     aliases = set()
                     primary_school_name = record.get("SCHOOL")
@@ -34,15 +34,19 @@ class Command(BaseCommand):
                     state = record.get('STATE')
                     school_id = int(record['SCHOOL_ID'])
                     data_json = dumps(record)
-                    school = School(school_id=school_id,
-                            city=city,
-                            state=state,
-                            data_json=data_json)
+                    school = School(
+                        school_id=school_id,
+                        city=city,
+                        state=state,
+                        data_json=data_json
+                    )
                     school.save()
                     school.alias_set.all().delete()
                     for (index, alias_str) in enumerate(aliases):
-                        alias = Alias(institution=school,
-                                alias=alias_str,
-                                is_primary=(alias_str == primary_school_name))
+                        alias = Alias(
+                            institution=school,
+                            alias=alias_str,
+                            is_primary=(alias_str == primary_school_name)
+                        )
                         alias.save()
                 self.stdout.write("... done!")

--- a/comparisontool/models.py
+++ b/comparisontool/models.py
@@ -1,6 +1,8 @@
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 
+@python_2_unicode_compatible
 class School(models.Model):
     """
     Represents a school
@@ -10,8 +12,8 @@ class School(models.Model):
     city = models.CharField(max_length=50)
     state = models.CharField(max_length=2)
 
-    def __unicode__(self):
-        return self.primary_alias + u"(%s)" % self.school_id
+    def __str__(self):
+        return self.primary_alias + "(%s)" % self.school_id
 
     @property
     def primary_alias(self):
@@ -21,6 +23,7 @@ class School(models.Model):
             return 'Not Available'
 
 
+@python_2_unicode_compatible
 class Alias(models.Model):
     """
     One of potentially several names for a school
@@ -29,8 +32,8 @@ class Alias(models.Model):
     alias = models.TextField()
     is_primary = models.BooleanField(default=False)
 
-    def __unicode__(self):
-        return u"%s (alias for %s)" % (self.alias, unicode(self.institution))
+    def __str__(self):
+        return "%s (alias for %s)" % (self.alias, self.institution)
 
 
 class BAHRate(models.Model):

--- a/comparisontool/search_indexes.py
+++ b/comparisontool/search_indexes.py
@@ -1,5 +1,5 @@
-from haystack import indexes
 from comparisontool.models import School
+from haystack import indexes
 
 
 class SchoolIndex(indexes.SearchIndex, indexes.Indexable):

--- a/comparisontool/tests/management/commands/test_load_bah.py
+++ b/comparisontool/tests/management/commands/test_load_bah.py
@@ -9,7 +9,7 @@ from comparisontool.models import BAHRate
 class LoadBAHTests(TestCase):
     def test_load_from_csv_creates_bahrate_objects(self):
         with tempfile.NamedTemporaryFile() as tf:
-            tf.write('ZIP,BAH\n22203,123\n22205,0\n22207,456\n')
+            tf.write(b'ZIP,BAH\n22203,123\n22205,0\n22207,456\n')
             tf.seek(0)
 
             call_command('load_bah', tf.name)

--- a/comparisontool/tests/management/commands/test_load_school.py
+++ b/comparisontool/tests/management/commands/test_load_school.py
@@ -10,9 +10,9 @@ class LoadSchoolTests(TestCase):
     def test_load_from_csv_creates_school_and_alias_objects(self):
         with tempfile.NamedTemporaryFile() as tf:
             tf.write(
-                'SCHOOL_ID,SCHOOL,ALIAS,CITY,STATE\n'
-                '1,Harvard,Big H|The Harv,Cambridge,MA\n'
-                '2,University of Pennsylvania,UPenn|Penn,Philadelphia,PA\n'
+                b'SCHOOL_ID,SCHOOL,ALIAS,CITY,STATE\n'
+                b'1,Harvard,Big H|The Harv,Cambridge,MA\n'
+                b'2,University of Pennsylvania,UPenn|Penn,Philadelphia,PA\n'
             )
             tf.seek(0)
 
@@ -23,7 +23,7 @@ class LoadSchoolTests(TestCase):
         harvard = School.objects.first()
         self.assertEqual(harvard.city, 'Cambridge')
         self.assertEqual(harvard.state, 'MA')
-        self.assertItemsEqual(
+        self.assertCountEqual(
             harvard.alias_set.values_list('alias', flat=True),
             ['Harvard', 'Big H', 'The Harv']
         )

--- a/comparisontool/tests/settings.py
+++ b/comparisontool/tests/settings.py
@@ -1,5 +1,7 @@
-import dj_database_url
 import os
+
+import dj_database_url
+
 
 DEBUG = True
 
@@ -11,7 +13,7 @@ DATABASES = {
 }
 
 if 'DATABASE_URL' in os.environ:
-    DATABASES['default']  =  dj_database_url.config()
+    DATABASES['default'] = dj_database_url.config()
 
 HAYSTACK_CONNECTIONS = {
     'default': {
@@ -28,7 +30,7 @@ ROOT_URLCONF = 'comparisontool.urls'
 SECRET_KEY = 'this-is-just-for-tests-so-not-that-secret'
 SITE_ID = 1
 
-TEMPLATES  =  [
+TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'APP_DIRS': True,

--- a/comparisontool/tests/test_forms.py
+++ b/comparisontool/tests/test_forms.py
@@ -1,9 +1,7 @@
 from unittest import TestCase
 from uuid import uuid4
 
-from comparisontool.forms import (
-    BAHZipSearchForm, EmailForm, SchoolSearchForm
-)
+from comparisontool.forms import BAHZipSearchForm, EmailForm, SchoolSearchForm
 
 
 class BAHZipSearchFormTests(TestCase):

--- a/comparisontool/tests/test_models.py
+++ b/comparisontool/tests/test_models.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from django.test import TestCase
 
 from comparisontool.models import Alias, School
@@ -39,7 +40,7 @@ class SchoolTests(TestCase):
             city='Washington',
             state='DC'
         )
-        alias = Alias.objects.create(
+        Alias.objects.create(
             institution=school,
             alias='foo',
             is_primary=True

--- a/comparisontool/tests/test_models.py
+++ b/comparisontool/tests/test_models.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.test import TestCase
 
 from comparisontool.models import Alias, School
@@ -17,7 +18,7 @@ class AliasTests(TestCase):
             is_primary=True
         )
 
-        self.assertEqual(unicode(alias), 'foo (alias for foo(1))')
+        self.assertEqual(str(alias), 'foo (alias for foo(1))')
 
 
 class SchoolTests(TestCase):
@@ -29,7 +30,7 @@ class SchoolTests(TestCase):
             state='DC'
         )
 
-        self.assertEqual(unicode(school), 'Not Available(1)')
+        self.assertEqual(str(school), 'Not Available(1)')
 
     def test_unicode_alias(self):
         school = School.objects.create(
@@ -44,4 +45,4 @@ class SchoolTests(TestCase):
             is_primary=True
         )
 
-        self.assertEqual(unicode(school), 'foo(1)')
+        self.assertEqual(str(school), 'foo(1)')

--- a/comparisontool/tests/test_validators.py
+++ b/comparisontool/tests/test_validators.py
@@ -1,5 +1,5 @@
-from django.test import TestCase
 from django.core.exceptions import ValidationError
+from django.test import TestCase
 
 from comparisontool.validators import validate_uuid4
 

--- a/comparisontool/tests/test_views.py
+++ b/comparisontool/tests/test_views.py
@@ -1,9 +1,12 @@
+from __future__ import unicode_literals
+
 import json
 import uuid
 
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import RequestFactory, TestCase
+from django.utils.encoding import force_text
 
 from comparisontool.models import BAHRate, School, Worksheet
 from comparisontool.views import (
@@ -70,8 +73,8 @@ class DataStorageViewTests(TestCase):
 
         view = DataStorageView.as_view()
         response = view(request, guid=self.worksheet.guid)
-        self.assertEqual(
-            json.loads(response.content),
+        self.assertJSONEqual(
+            force_text(response.content),
             {'id': self.worksheet.guid}
         )
 
@@ -166,7 +169,7 @@ class SchoolRepresentationTests(TestCase):
     def test_valid_school_returns_school_data_json(self):
         school = School.objects.create(
             school_id=123,
-            data_json='{"foo": "bar"}'
+            data_json=b'{"foo": "bar"}'
         )
 
         response = self.client.get(self.path(school_id=123))
@@ -186,15 +189,15 @@ class SchoolSearchAPITests(TestCase):
         )
 
         request = self.factory.get('/?q=s')
-        self.assertEqual(
-            school_search_api(request).content,
-            json.dumps([{
+        self.assertJSONEqual(
+            force_text(school_search_api(request).content),
+            [{
                 'schoolname': None,
                 'id': 123,
                 'city': 'Washington',
                 'state': 'DC',
                 'url': reverse('school-json', args=(123,)),
-            }])
+            }]
         )
 
     def test_invalid_request_returns_empty_dict(self):

--- a/comparisontool/tests/test_views.py
+++ b/comparisontool/tests/test_views.py
@@ -10,8 +10,10 @@ from django.utils.encoding import force_text
 
 from comparisontool.models import BAHRate, School, Worksheet
 from comparisontool.views import (
-    DataStorageView, WorksheetJsonValidationError, bah_lookup_api,
-    school_search_api
+    DataStorageView,
+    WorksheetJsonValidationError,
+    bah_lookup_api,
+    school_search_api,
 )
 
 
@@ -20,7 +22,7 @@ class BAHLookupAPITests(TestCase):
         self.factory = RequestFactory()
 
     def test_valid_request_returns_rate(self):
-        rate = BAHRate.objects.create(zip5='22203', value='1234')
+        BAHRate.objects.create(zip5='22203', value='1234')
         request = self.factory.get('/?zip5=22203')
         self.assertContains(bah_lookup_api(request), '{"rate": 1234}')
 
@@ -136,8 +138,8 @@ class EmailLinkTests(TestCase):
 
     def test_valid_post_sends_email(self):
         guid = uuid.uuid4()
-        worksheet = Worksheet.objects.create(guid=guid)
-        response = self.client.post(
+        Worksheet.objects.create(guid=guid)
+        self.client.post(
             self.path,
             {'id': guid, 'email': 'foo@bar.com'}
         )
@@ -162,7 +164,7 @@ class SchoolRepresentationTests(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_valid_school_returns_json(self):
-        school = School.objects.create(school_id=123)
+        School.objects.create(school_id=123)
         response = self.client.get(self.path(school_id=123))
         self.assertEqual(response['Content-type'], 'application/json')
 
@@ -181,7 +183,7 @@ class SchoolSearchAPITests(TestCase):
         self.factory = RequestFactory()
 
     def test_valid_request_returns_matching_school(self):
-        school = School.objects.create(
+        School.objects.create(
             school_id=123,
             data_json='',
             city='Washington',

--- a/comparisontool/urls.py
+++ b/comparisontool/urls.py
@@ -1,33 +1,90 @@
 from django.conf.urls import url
+from django.views.generic import TemplateView
 
-from comparisontool.views import *
+from comparisontool.views import (
+    BuildComparisonView,
+    CreateWorksheetView,
+    DataStorageView,
+    EmailLink,
+    SchoolRepresentation,
+    bah_lookup_api,
+    school_search_api,
+)
 
 
 urlpatterns = [
-    url(r'^$', TemplateView.as_view(template_name='comparisontool/landing.html'), name='pfc-landing'),
-    url(r'^choose-a-student-loan/$', TemplateView.as_view(template_name='comparisontool/choose_a_loan.html'), name='pfc-choose'),
-    url(r'^manage-your-college-money/$', TemplateView.as_view(template_name='comparisontool/manage_your_money.html'), name='pfc-manage'),
-    url(r'^repay-student-debt/$', TemplateView.as_view(template_name='comparisontool/repay_student_debt.html'), name='pfc-repay'),
+    url(
+        r'^$',
+        TemplateView.as_view(
+            template_name='comparisontool/landing.html'
+        ),
+        name='pfc-landing'
+    ),
+    url(
+        r'^choose-a-student-loan/$',
+        TemplateView.as_view(
+            template_name='comparisontool/choose_a_loan.html'
+        ),
+        name='pfc-choose'
+    ),
+    url(
+        r'^manage-your-college-money/$',
+        TemplateView.as_view(
+            template_name='comparisontool/manage_your_money.html'
+        ),
+        name='pfc-manage'
+    ),
+    url(
+        r'^repay-student-debt/$',
+        TemplateView.as_view(
+            template_name='comparisontool/repay_student_debt.html'
+        ),
+        name='pfc-repay'
+    ),
 
-    url(r'^compare-financial-aid-and-college-cost/$', BuildComparisonView.as_view(), name='worksheet'),
-    url(r'^compare-financial-aid-and-college-cost/api/email/$', EmailLink.as_view(), name='email'),
+    url(
+        r'^compare-financial-aid-and-college-cost/$',
+        BuildComparisonView.as_view(),
+        name='worksheet'
+    ),
+    url(
+        r'^compare-financial-aid-and-college-cost/api/email/$',
+        EmailLink.as_view(),
+        name='email'
+    ),
 
-    url(r'^compare-financial-aid-and-college-cost/technote/$',
+    url(
+        r'^compare-financial-aid-and-college-cost/technote/$',
         TemplateView.as_view(template_name="comparisontool/technote.html"),
-        name='pfc-technote'),
+        name='pfc-technote'
+    ),
 
-    url(r'^compare-financial-aid-and-college-cost/api/search-schools.json', school_search_api),
-    url(r'^compare-financial-aid-and-college-cost/api/bah-lookup.json', bah_lookup_api),
+    url(
+        r'^compare-financial-aid-and-college-cost/api/search-schools.json',
+        school_search_api
+    ),
 
-    url(r'^compare-financial-aid-and-college-cost/api/school/(\d+).json',
+    url(
+        r'^compare-financial-aid-and-college-cost/api/bah-lookup.json',
+        bah_lookup_api
+    ),
+
+    url(
+        r'^compare-financial-aid-and-college-cost/api/school/(\d+).json',
         SchoolRepresentation.as_view(),
-        name='school-json'),
+        name='school-json'
+    ),
 
-    url(r'^compare-financial-aid-and-college-cost/api/worksheet/([1-z0-9-]*).json$',
+    url(
+        r'^compare-financial-aid-and-college-cost/api/worksheet/([1-z0-9-]*)'
+        r'.json$',
         DataStorageView.as_view(),
-        name='worksheet'),
+        name='worksheet'
+    ),
 
-    url(r'^compare-financial-aid-and-college-cost/api/worksheet/$',
+    url(
+        r'^compare-financial-aid-and-college-cost/api/worksheet/$',
         CreateWorksheetView.as_view(),
-        name='create_worksheet')
+        name='create_worksheet'
+    )
 ]

--- a/comparisontool/validators.py
+++ b/comparisontool/validators.py
@@ -2,8 +2,9 @@ from uuid import UUID
 
 from django.core.exceptions import ValidationError
 
+
 def validate_uuid4(value):
-    try: 
-       valid_uuid = UUID(value,version=4) 
+    try:
+        UUID(value, version=4)
     except ValueError:
         raise ValidationError('%s is not a valid uuid4' % value)

--- a/comparisontool/views.py
+++ b/comparisontool/views.py
@@ -2,17 +2,16 @@
 import json
 import uuid
 
-from django.core.urlresolvers import reverse
-from django.views.generic import TemplateView, View
-from django.shortcuts import get_object_or_404, render
 from django.core.mail import send_mail
-from django.template.loader import get_template
+from django.core.urlresolvers import reverse
 from django.http import HttpResponse
+from django.shortcuts import get_object_or_404, render
+from django.template.loader import get_template
+from django.views.generic import View
 
+from comparisontool.forms import BAHZipSearchForm, EmailForm, SchoolSearchForm
+from comparisontool.models import BAHRate, School, Worksheet
 from haystack.query import SearchQuerySet
-
-from comparisontool.models import School, Worksheet, BAHRate
-from comparisontool.forms import EmailForm, SchoolSearchForm, BAHZipSearchForm
 
 
 class WorksheetJsonValidationError(Exception):

--- a/comparisontool/views.py
+++ b/comparisontool/views.py
@@ -11,8 +11,8 @@ from django.http import HttpResponse
 
 from haystack.query import SearchQuerySet
 
-from models import School, Worksheet, BAHRate
-from forms import EmailForm, SchoolSearchForm, BAHZipSearchForm
+from comparisontool.models import School, Worksheet, BAHRate
+from comparisontool.forms import EmailForm, SchoolSearchForm, BAHZipSearchForm
 
 
 class WorksheetJsonValidationError(Exception):

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,10 @@ envlist=py{27,36}-dj{111}-{sqlite,postgres}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
-commands=coverage run ./manage.py test
+commands=
+    coverage erase
+    coverage run ./manage.py test
+    coverage report -m
 
 basepython=
     py27: python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,15 @@
 skipsdist=True
 usedevelop=True
 
-envlist=dj{111}-{sqlite,postgres}
+envlist=py{27,36}-dj{111}-{sqlite,postgres}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=coverage run ./manage.py test
+
+basepython=
+    py27: python2.7
+    py36: python3.6
 
 deps=
     coverage==4.2

--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,33 @@ deps=
 setenv=
     postgres: DATABASE_URL=postgres://localhost/dccc
     sqlite: DATABASE_URL=sqlite:///:memory:
+
+[testenv:lint]
+basepython=python3.6
+deps=
+    flake8
+    isort
+commands=
+    flake8 comparisontool
+    isort --check-only --diff --recursive comparisontool
+
+[flake8]
+ignore = E731, W503, W504,
+
+exclude =
+    .git,
+    .tox,
+    __pycache__,
+    */migrations/*.py,
+
+[isort]
+include_trailing_comma=1
+multi_line_output=3
+skip=.tox,migrations
+not_skip=__init__.py
+use_parentheses=1
+known_django=django
+known_future_library=future,six
+known_third_party=mock
+default_section=THIRDPARTY
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
This PR adds support for Python 3.6, and adds the Python 3.6 test environments, linting, and coverage reporting to tox.

To make navigating the diff easier, the Python 3-compatibility is in 4afc42b. Linting fixes are in 4c6c03c.
