### PR TITLE
Migrate icons to SVG

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+Short description explaining the high-level reason for the new issue.
+
+## Current behavior
+
+
+## Expected behavior
+
+
+## Steps to replicate behavior (include URLs)
+
+1.
+
+
+## Screenshots
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+Short description explaining the high-level reason for the pull request
+
+## Additions
+
+-
+
+## Removals
+
+-
+
+## Changes
+
+-
+
+## Testing
+
+-
+
+## Screenshots
+
+
+## Notes
+
+-
+
+## Todos
+
+-
+
+## Checklist
+
+* [ ] Changes are limited to a single goal (no scope creep)
+* [ ] Code can be automatically merged (no conflicts)
+* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
+* [ ] Passes all existing automated tests
+* [ ] New functions include new tests
+* [ ] New functions are documented (with a description, list of inputs, and expected output)
+* [ ] Placeholder code is flagged
+* [ ] Visually tested in supported browsers and devices
+* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
+

--- a/comparisontool/static/choosealoan/css/guides.css
+++ b/comparisontool/static/choosealoan/css/guides.css
@@ -57,9 +57,11 @@ h4 {font-size:14px;font-weight:500;}
 .ico-explore{ background-position: 0 -77px; width: 23px; height: 13px; margin-bottom:7px; }
 .ico-compare{ background-position: 0 -110px; width: 19px; height: 19px; margin-bottom:1px; }
 .icon {width:23px;height:23px;background: url("/static/choosealoan/images/icons.png") no-repeat top left;position:absolute;}
-.ico-bullet_check{ background-position: 0 0; width: 17px; height: 17px;}
-.ico-bullet_minus{ background-position: -37px 0; width: 17px; height: 17px;}
-.ico-bullet_plus{ background-position: -74px 0; width: 17px; height: 17px; }
+
+.ico-bullet_check .cf-icon-svg{ color: #20aa3f; }
+.ico-bullet_minus .cf-icon-svg{ color: #d14124; }
+.ico-bullet_plus .cf-icon-svg{ color: #257675; }
+
 .ico-criteria_eligibility{ background-position: -111px 0; width: 21px; height: 19px; }
 .ico-criteria_interest{ background-position: -152px 0; width: 20px; height: 18px; }
 .ico-criteria_limits{ background-position: -192px 0; width: 23px; height: 17px; }
@@ -71,8 +73,9 @@ h4 {font-size:14px;font-weight:500;}
 .ico-process-loans{ background-position: -94px 0; }
 .ico-process-loans.selected,
 .ico-process-loans:hover { background-position: -141px 0; }
-.icon-positioning-fix {position: relative; display: block; }
-.icon-positioning-fix .icon { left:-23px; top:-14px;}
+.icon-positioning-fix {position: relative; display: block;}
+.icon-positioning-fix .cf-icon-svg {left:-15px; top:0;position: absolute;font-size:1.2em;}
+.no-pad .icon-positioning-fix .cf-icon-svg {left:-23px;}
 .rh{text-align:right;}
 .uc {text-transform:uppercase; font-weight:400;}
 .no-pad{padding:0px;}
@@ -268,8 +271,6 @@ h3 {text-transform:none; color:#212121;}
 .comparison-h2{font-size:24px;}
 p {line-height:1.4em;}
 .rel-ico-span{position: relative;width:300px;margin-left:21px; float:left; height:100%;}
-.rel-ico-span h4{margin-left:22px;}
-.rel-ico-span .icon{margin-top:1px;}
 #ask-cfpb-print {display:none;}
 .guide-hero{margin-top:40px;}
 
@@ -349,11 +350,30 @@ thead th {padding:1px;}
 h2{text-transform:none;margin-left:0px;letter-spacing:0px;}
 .td2 h2{font-weight:500; padding-bottom:.4em; border-bottom:1px solid #212121;}
 #ask-cfpb-print{display:none;}
+
+/* Round numbered bullets. */
 ol.action-steps,ul.action-steps {padding:0; list-style: none;}
-ol.action-steps li {margin-bottom:10px;padding-left:30px;background-position-y:2px;}
-ol.action-steps .li-1 {background-image:url("/static/choosealoan/images/bullet-1.png");background-repeat: no-repeat;}
-ol.action-steps .li-2 {background-image:url("/static/choosealoan/images/bullet-2.png");background-repeat: no-repeat;}
-ol.action-steps .li-3 {background-image:url("/static/choosealoan/images/bullet-3.png");background-repeat: no-repeat;}
+ol.action-steps li {margin-bottom:10px;padding-left:30px;}
+ol.action-steps {counter-reset: bullets;}
+ol.action-steps li {position: relative;}
+ol.action-steps li:before {
+    counter-increment: bullets;
+    content: counter( bullets );
+    position: absolute;
+    top: 3px;
+    left: 0;
+    background: #000;
+    color: #fff;
+    width: 1.7em;
+    height: 1.5em;
+    padding-top: 0.2em;
+    text-align: center;
+    display: table-cell;
+    vertical-align: middle;
+    border-radius: 100%;
+    font-size: 0.7em;
+}
+
 .intro-row {margin-top: 50px;}
 .intro-row{margin-left:-20px;font-family: "Avenir Next", Arial, sans-serif;}
 .intro-row:before,.row:after{content:"";display:table;}

--- a/comparisontool/static/choosealoan/css/print.css
+++ b/comparisontool/static/choosealoan/css/print.css
@@ -24,7 +24,7 @@ body {font-family: "Avenir Next"; color: #000 !important;}
 
 .well-solid h1 {font-size:32px; text-transform:none; line-height:36px;}
 .guide-hero h1,
-.guide-hero h2 {text-transform:none; margin:0;} 
+.guide-hero h2 {text-transform:none; margin:0;}
 .guide-hero h1 {font-size:32px; line-height:36px; font-weight:500; letter-spacing: .5px; margin-bottom:8px; padding-top:.67em;}
 .guide-hero h2 {font-size:32px; line-height:36px;}
 
@@ -50,7 +50,7 @@ body {font-family: "Avenir Next"; color: #000 !important;}
 .related-resources p {margin: 0px; font-size: 14px; line-height: 20px;}
 
 #its-important { }
-#print-questions {display:block; text-transform: none; font-size: 18px; font-weight: 400; color:#212121;} 
+#print-questions {display:block; text-transform: none; font-size: 18px; font-weight: 400; color:#212121;}
 #print-questions ul, li {font-family:"Georgia"; font-size: 12px;}
 #print-questions h2 {}
 
@@ -63,8 +63,8 @@ a, .lnk {border-bottom:1px dotted #004D6B; text-decoration:none; color: #3A7188;
 a.ec,a.ec-blk {
     font-weight:500;
     text-decoration:none;
-    padding-left:0px;   
-    background-repeat:no-repeat; 
+    padding-left:0px;
+    background-repeat:no-repeat;
     background-position-x:0px;
     background-position-y:0px;
 }
@@ -132,10 +132,10 @@ ol .li-3 {background-image:url(../images/bullet-3.png);background-repeat: no-rep
 }
 
 .ico {background: url(../images/resources.png) no-repeat top left;padding-left:26px;padding-top:3px;}
-.ico-ask { background-position: 0 0; width: 12px; height: 17px; } 
-.ico-watch{ background-position: 0 -37px; width: 21px; height: 20px; } 
-.ico-explore{ background-position: 0 -77px; width: 23px; height: 13px; } 
-.ico-compare{ background-position: 0 -110px; width: 19px; height: 19px; } 
+.ico-ask { background-position: 0 0; width: 12px; height: 17px; }
+.ico-watch{ background-position: 0 -37px; width: 21px; height: 20px; }
+.ico-explore{ background-position: 0 -77px; width: 23px; height: 13px; }
+.ico-compare{ background-position: 0 -110px; width: 19px; height: 19px; }
 
 /* Options Table */
 table{border:0px;border-collapse: separate;border-spacing: 18px 0px;padding-bottom: 20px;}
@@ -166,11 +166,11 @@ td, .smlr-text{font-family: georgia;font-size: 12px;line-height: 20px;font-weigh
 #print-ask-cfpb li {font-size:14px;line-height:20px;font-family: Georgia; margin:0 0 10px;}
 .bullet {float:left; display:inline-block;height:25px;width:25px;text-align:center;line-height:26px;font-size:1.5em;border-radius:100%;-moz-border-radius:100%;-webkit-border-radius:100%; margin-right:5px;font-weight:600; margin-top:-6px;}
 
-.ico-criteria_repayment{ background-position: -235px 0; width: 20px; height: 19px; } 
+.ico-criteria_repayment{ background-position: -235px 0; width: 20px; height: 19px; }
 .print-hide{display:none;}
 .accordion-item{display:block !important;}
 
-.ico-criteria_repayment{ background-position: -235px 0; width: 20px; height: 19px; } 
+.ico-criteria_repayment{ background-position: -235px 0; width: 20px; height: 19px; }
 .print-hide{display:none;}
 
 @page {

--- a/comparisontool/static/repaystudentdebt/css/repay.css
+++ b/comparisontool/static/repaystudentdebt/css/repay.css
@@ -4138,6 +4138,18 @@ tbody > tr:nth-child(odd) > #repaying-student-debt td {
   font-weight: bold;
 }
 
+#repaying-student-debt .cf-icon-svg {
+  font-size: 1.75em;
+  position: relative;
+  top: -0.25em;
+}
+
+#repaying-student-debt a .cf-icon-svg {
+  /* Reset the icon position and size for external link icons. */
+  font-size: 1em;
+  top: 0;
+}
+
 #repaying-student-debt .ds-section .ds-response-container {
   border-bottom: 1px solid #A9ABAC;
   font-family: "AvenirNextLTW01-Regular", Arial, sans-serif;

--- a/comparisontool/static/repaystudentdebt/css/repay.css
+++ b/comparisontool/static/repaystudentdebt/css/repay.css
@@ -1206,13 +1206,8 @@ button#repaying-student-debt .expandable_header {
 #repaying-student-debt .expandable-group .expandable_content {
   margin-bottom: 0;
 }
-#repaying-student-debt .cf-icon-svg,
 #repaying-student-debt .cf-icon-svg {
   display: inline-block;
-  font-style: normal;
-  font-weight: normal;
-  line-height: 1;
-  -webkit-font-smoothing: antialiased;
 }
 #repaying-student-debt .content-l {
   position: relative;
@@ -4141,12 +4136,6 @@ tbody > tr:nth-child(odd) > #repaying-student-debt td {
 #repaying-student-debt .ds-module h3 {
   font-size: 1.125em;
   font-weight: bold;
-}
-
-#repaying-student-debt .cf-icon-svg {
-  font-size: 1.75em;
-  position: relative;
-  top: -0.25em;
 }
 
 #repaying-student-debt .ds-section .ds-response-container {

--- a/comparisontool/templates/comparisontool/choose_a_loan.html
+++ b/comparisontool/templates/comparisontool/choose_a_loan.html
@@ -22,10 +22,6 @@
 {% block page_css %}
     <link href="{% static 'choosealoan/css/guides.css' %}" rel="stylesheet" media="screen">
     <link href="{% static 'choosealoan/css/print.css' %}" rel="stylesheet" media="print">
-    <link rel='stylesheet' id='cfpb_icon_font-css'  href="{% static 'nemo/_/cfpb-icon-font/css/icons.css' %}" type="text/css" media="all">
-    <!--[if IE 7]>
-    <link rel="stylesheet" id="cfpb_icon_font_ie7-css"  href="/wp-content/themes/cfpb_nemo/_/cfpb-icon-font/css/icons-ie7.css?ver=all" type="text/css" media="all" />
-    <![endif]-->
 {% endblock %}
 
 {% block body_class %}page paying-for-college{% endblock %}
@@ -35,7 +31,12 @@
     <div id="pfc-hero-wrapper" class="pfc-hero-wrapper clearfix">
         <div class="pfc-hero-content">
             <div class="breadcrumbs">
-                <p><i class="icon-left"></i><a href="/paying-for-college/">Paying for College</a></p>
+                <p>
+                    <a href="/paying-for-college/">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 559.6 1200" class="cf-icon-svg"><path d="M494.5 1090.7c-17.3 0-33.8-6.8-46-19L19 642.1c-25.4-25.4-25.4-66.5 0-91.9l429.5-429.5c25.6-25.1 66.8-24.8 91.9.8 24.8 25.3 24.8 65.8 0 91.1L156.9 596.2l383.6 383.6c25.4 25.4 25.4 66.5.1 91.9-12.3 12.2-28.8 19-46.1 19z"></path></svg>
+                        Paying for College
+                    </a>
+                </p>
             </div>
             <h1 class="sub-page">Choosing a loan</h1>
             <p>Three steps that can help you get the right loan for you.</p>
@@ -210,8 +211,8 @@
                     <tbody class="">
                         <tr>
                             <td class="rh font-m uc ico-repayment no-pad">
-                                <div class="icon-positioning-fix">
-                                    <div class="icon ico-bullet_check"></div>
+                                <div class="icon-positioning-fix ico-bullet_check">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
                                 </div>
                                 What you need to know
                             </td>
@@ -224,8 +225,8 @@
                         </tr>
                         <tr>
                             <td class="rh font-m uc ico-interest no-pad">
-                                <div class="icon-positioning-fix">
-                                    <div class="icon ico-bullet_plus"></div>
+                                <div class="icon-positioning-fix ico-bullet_plus">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H549.6v213.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V655.9H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h213.6V342.3c0-27.6 22.4-50 50-50s50 22.4 50 50v213.6h213.6c27.6 0 50 22.4 50 50s-22.5 50-50.1 50z"></path></svg>
                                 </div>
                                 Benefits
                             </td>
@@ -238,8 +239,8 @@
                         </tr>
                         <tr>
                             <td class="rh font-m uc ico-eligibility no-pad">
-                                <div class="icon-positioning-fix">
-                                    <div class="icon ico-bullet_minus"></div>
+                                <div class="icon-positioning-fix ico-bullet_minus">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h527.1c27.6 0 50 22.4 50 50s-22.4 50-50 50z"></path></svg>
                                 </div>
                                 Risks
                             </td>

--- a/comparisontool/templates/comparisontool/landing.html
+++ b/comparisontool/templates/comparisontool/landing.html
@@ -31,10 +31,6 @@
 
 {% block page_css %}
     <link rel="stylesheet" href="{% static 'landing/css/landing.css' %}">
-    <link rel='stylesheet' id='cfpb_icon_font-css'  href="{% static 'nemo/_/cfpb-icon-font/css/icons.css' %}" type="text/css" media="all">
-    <!--[if IE 7]>
-    <link rel="stylesheet" id="cfpb_icon_font_ie7-css"  href="{% static 'nemo/_/cfpb-icon-font/css/icons-ie7.css' %}" type="text/css" media="all" />
-    <![endif]-->
 {% endblock %}
 
 {% block content %}
@@ -80,9 +76,18 @@
                 <div class="share-pfc">
                     <h3 class="h4">Share this page</h3>
                     <div class="share-links">
-                        <a href="http://www.facebook.com/sharer.php?u={% firstof share_uri request.build_absolute_uri|urlencode %}&t={{ pagetitle|default:"CFPB" }}" class="share-facebook icon-facebook-alt" ><span class="cfpb_visually_hide">Share on Facebook</span></a>
-                        <a href="http://twitter.com/share?text={% firstof tweet_text pagetitle "CFPB" %}&url={% firstof share_uri request.build_absolute_uri|urlencode %}&via=CFPB&related=CFPB" class="share-twitter icon-twitter-alt"><span class="cfpb_visually_hide">Share on Twitter</span></a>
-                        <a class="share-email addthis_button_email icon-email-social-alt" href="http://api.addthis.com/oexchange/0.8/forward/email/offer?url={% firstof share_uri request.build_absolute_uri|urlencode %}&title={% firstof email_title "CFPB" %}&pubid=ra-4da354ee346886d2"><span class="cfpb_visually_hide">Share via Email</span></a>
+                        <a href="http://www.facebook.com/sharer.php?u={% firstof share_uri request.build_absolute_uri|urlencode %}&t={{ pagetitle|default:"CFPB" }}" class="share-facebook icon-facebook-alt" >
+                            <span class="cfpb_visually_hide">Share on Facebook</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M0 105.2v1000h1000v-1000H0zm847 564.2H710.5v365.9H570.9V669.4h-96.7V537.6h96.7V425.2c0-88.5 57.2-169.6 188.8-169.6 53.4 0 92.9 5.1 92.9 5.1l-3.3 123.2s-40.1-.4-84-.4c-47.3 0-54.9 21.7-54.9 58v96.1h142.8L847 669.4z"></path></svg>
+                        </a>
+                        <a href="http://twitter.com/share?text={% firstof tweet_text pagetitle "CFPB" %}&url={% firstof share_uri request.build_absolute_uri|urlencode %}&via=CFPB&related=CFPB" class="share-twitter icon-twitter-alt">
+                            <span class="cfpb_visually_hide">Share on Twitter</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M0 105.2v1000h1000v-1000H0zm788.4 352c.3 6.4.4 12.8.4 19.2 0 196.7-149.7 423.5-423.5 423.5-80.9.1-160.1-23.2-228.1-66.9 11.8 1.4 23.6 2.1 35.5 2.1 67 .1 132.1-22.4 184.9-63.7-63.7-1.2-119.5-42.8-139-103.4 9.2 1.8 18.6 2.7 28 2.7 13.3 0 26.5-1.8 39.3-5.2-69.5-14-119.4-75.1-119.5-145.9v-1.9c20.7 11.5 43.8 17.9 67.4 18.6-65.4-43.7-85.6-130.7-46-198.7 73.4 90.1 183 149.3 306.7 155.5-2.6-11.1-3.9-22.5-3.9-33.9.1-82.3 67-148.9 149.3-148.7 41 .1 80.2 17 108.2 46.9 33.3-6.6 65.3-18.8 94.5-36.1-11.1 34.5-34.4 63.8-65.5 82.4 29.5-3.5 58.3-11.4 85.5-23.4-19.9 29.8-45 55.9-74.2 76.9z"></path></svg>
+                        </a>
+                        <a class="share-email addthis_button_email icon-email-social-alt" href="http://api.addthis.com/oexchange/0.8/forward/email/offer?url={% firstof share_uri request.build_absolute_uri|urlencode %}&title={% firstof email_title "CFPB" %}&pubid=ra-4da354ee346886d2">
+                            <span class="cfpb_visually_hide">Share via Email</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M0 105.2v1000h1000v-1000H0zm790.9 322.9l-234 172.5c-14.8 10.9-35.8 17.2-57.6 17.2s-42.8-6.2-57.6-17.2l-234-172.5h583.2zm-645.1 16.4l239.7 176.8-239.7 153.6V444.5zm80.5 338.2L430.2 652c20.4 10.2 44.2 15.8 69.1 15.8s48.7-5.5 69-15.8l203.8 130.7H226.3zm626.5-7.7L613.1 621.3l239.7-176.8V775z"></path></svg>
+                        </a>
                     </div>
                 </div>
             </div>
@@ -92,7 +97,7 @@
             <header class="border-overlay-spacing">
                 <h2 class="h4 border-overlay">Student financial guides</h2>
             </header>
-            <div class="col col8">
+            <div class="col col8 u-mb30">
                 <p>For many people, how to pay for a college education is one of the first major financial decisions they'll make. These guides cover some of the big decisions you’ll face and will help you understand your options for financing your college education.</p>
             </div>
             <div class="clearfix">
@@ -100,8 +105,13 @@
                     <h3>Student loans</h3>
                     <p>If you’re considering student loans to help you pay for school, you’re not alone – many students need loans to cover their full cost of attendance. If you have to take out student loans, comparing your options can help you find the student loan best suited for your needs. <a href="/paying-for-college/choose-a-student-loan/">More about student loans</a>.</p>
 
-                    <p>Still need to apply for financial aid? <br><a href="https://fafsa.gov/" target="_blank" rel="noopener noreferrer">Visit fafsa.gov&nbsp;<i class="icon-external-link"></i></a>
-                </p>
+                    <p>
+                        Still need to apply for financial aid? <br>
+                        <a href="https://fafsa.gov/" target="_blank" rel="noopener noreferrer">
+                            Visit fafsa.gov
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 790.1 1200" class="cf-icon-svg"><path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg>
+                        </a>
+                    </p>
                 </div>
                 <div class="col last col6">
                     <h3>Student banking</h3>
@@ -115,9 +125,15 @@
                 <h2 class="h4 border-overlay">Compare financial aid offers</h2>
             </header>
             <div class="col last col8">
-                <p>As part of our <a href="http://www.consumerfinance.gov/students/knowbeforeyouowe/">Know Before You Owe project</a>, we worked with the Department of Education to create a <a class="pdf exit-link" href="http://collegecost.ed.gov/shopping_sheet.pdf">Financial Aid Shopping Sheet</a>. Now that thousands of colleges are adopting this clear and comparable form, we’ve built a tool that complements the shopping sheet to help students make comparisons tailored to their individual circumstances.</p>
+                <p>As part of our <a href="http://www.consumerfinance.gov/students/knowbeforeyouowe/">Know Before You Owe project</a>, we worked with the Department of Education to create a
+                    <a class="exit-link" href="http://collegecost.ed.gov/shopping_sheet.pdf">Financial Aid Shopping Sheet <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 651.7 1200" class="cf-icon-svg"><path d="M507.1 692.8c-15.6-15.6-40.9-15.6-56.6 0l-85.1 85.1V466.6c0-22.1-17.9-40-40-40s-40 17.9-40 40V778l-85.1-85.1c-15.6-15.6-40.9-15.6-56.6 0-15.6 15.6-15.6 40.9 0 56.6L297 902.9c7.5 7.5 17.7 11.7 28.3 11.7s20.8-4.2 28.3-11.7l153.3-153.4c15.8-15.7 15.8-41 .2-56.7z"></path><path d="M30 161c-16.5 0-30 13.5-30 30v827.8c0 16.5 13.5 30 30 30h591.7c16.5 0 30-13.5 30-30V343.7L469 161H30zm389.6 60v134.8c0 19.9 16.3 36.2 36.2 36.2h135.9V988.8H60V221h359.6z"></path></svg></a>. Now that thousands of colleges are adopting this clear and comparable form, we’ve built a tool that complements the shopping sheet to help students make comparisons tailored to their individual circumstances.</p>
                 <p><a class="button" href="/paying-for-college/compare-financial-aid-and-college-cost/">Compare costs</a></p>
-                <p>Still researching schools? <br><a class="exit-link" href="http://collegecost.ed.gov/scorecard/index.aspx" target="_blank" rel="noopener noreferrer">Check out College Scorecard&nbsp;<i class="icon-external-link"></i></a>
+                <p>
+                    Still researching schools? <br>
+                    <a class="exit-link" href="http://collegecost.ed.gov/scorecard/index.aspx" target="_blank" rel="noopener noreferrer">
+                        Check out College Scorecard
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 790.1 1200" class="cf-icon-svg"><path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg>
+                    </a>
                 </p>
             </div>
         </section>

--- a/comparisontool/templates/comparisontool/manage_your_money.html
+++ b/comparisontool/templates/comparisontool/manage_your_money.html
@@ -19,10 +19,6 @@
 {% block page_css %}
     <link href="{% static 'choosealoan/css/guides.css' %}" rel="stylesheet" media="screen">
     <link href="{% static 'choosealoan/css/print.css' %}" rel="stylesheet" media="print">
-    <link rel='stylesheet' id='cfpb_icon_font-css'  href="{% static 'nemo/_/cfpb-icon-font/css/icons.css' %}" type="text/css" media="all">
-    <!--[if IE 7]>
-    <link rel="stylesheet" id="cfpb_icon_font_ie7-css"  href="{% static 'nemo/_/cfpb-icon-font/css/icons-ie7.css' %}" type="text/css" media="all" />
-    <![endif]-->
 {% endblock %}
 
 {% block jquery %}
@@ -36,7 +32,12 @@
     <div id="pfc-hero-wrapper" class="pfc-hero-wrapper clearfix">
         <div class="pfc-hero-content">
             <div class="breadcrumbs">
-                <p><i class="icon-left"></i><a href="/paying-for-college/">Paying for College</a></p>
+				<p>
+					<a href="/paying-for-college/">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 559.6 1200" class="cf-icon-svg"><path d="M494.5 1090.7c-17.3 0-33.8-6.8-46-19L19 642.1c-25.4-25.4-25.4-66.5 0-91.9l429.5-429.5c25.6-25.1 66.8-24.8 91.9.8 24.8 25.3 24.8 65.8 0 91.1L156.9 596.2l383.6 383.6c25.4 25.4 25.4 66.5.1 91.9-12.3 12.2-28.8 19-46.1 19z"></path></svg>
+						Paying for College
+					</a>
+				</p>
             </div>
             <h1 class="sub-page">Managing college money</h1>
             <p>Practical advice on how to make sure you’re getting the best deal.</p>
@@ -157,15 +158,23 @@
 			<h2 class='comparison-h2'>Choosing a bank account</h2>
 <div class="row cf vspace2">
     <div class="rel-ico-span relative">
-    	<div class="icon ico-bullet_check"></div>
-		<h4 class="vspace1 offset-s">What you need to know</h4>
-		<p class="offset-s" style='color:#444;'><p>Shop around, and don't feel limited to only the banks or credit unions that have ATMs on or near campus; some will automatically reimburse fees for using any ATM. Consider accounts that offer services like remote check deposits, mobile apps, and online bill-pay.</p></p>
+		<h4 class="vspace1 offset-s">
+			<span class="ico-bullet_check">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
+			</span>
+			What you need to know
+		</h4>
+		<p>Shop around, and don't feel limited to only the banks or credit unions that have ATMs on or near campus; some will automatically reimburse fees for using any ATM. Consider accounts that offer services like remote check deposits, mobile apps, and online bill-pay.</p>
 	</div>
 	<div class="rel-ico-span relative">
-		<div class="icon ico-bullet_check"></div>
-		<h4 class="vspace1 offset-s">Keep in mind</h4>
-		<p class="offset-s" style='color:#444;'><p>Dig deeper when accounts are marketed as "free" or "easy" - very few accounts charge no fees at all.</p>
-<p>Signing up for a bank account now can save you headaches later, and researching accounts with the lowest fees can save you money.</p></p>
+		<h4 class="vspace1 offset-s">
+			<span class="ico-bullet_check">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
+			</span>
+			Keep in mind
+		</h4>
+		<p>Dig deeper when accounts are marketed as "free" or "easy" - very few accounts charge no fees at all.</p>
+		<p>Signing up for a bank account now can save you headaches later, and researching accounts with the lowest fees can save you money.</p>
 	</div>
 </div>
 
@@ -190,78 +199,65 @@
 			<tbody class="">
 			<tr>
 				<td class="rh font-m uc">
-                    <div class="icon-positioning-fix">
-					    <div class="icon ico-bullet_check"></div>
-                    </div>
+					<div class="icon-positioning-fix ico-bullet_check">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
+					</div>
 				    How it works
 				</td>
 			    <td class="thick-line">
-			    Some financial institutions provide exclusively online banking services that are comparable to a traditional checking account
+			    	Some financial institutions provide exclusively online banking services that are comparable to a traditional checking account
 			    </td>
 				<td class="thick-line">
-				Some banks and credit unions offer student checking accounts with discounted fees to establish long term relationships with new customers
+					Some banks and credit unions offer student checking accounts with discounted fees to establish long term relationships with new customers
 				</td>
 				<td class="thick-line">
-				Many colleges have a bank they partner with to offer students campus affiliated checking accounts or prepaid debit cards
+					Many colleges have a bank they partner with to offer students campus affiliated checking accounts or prepaid debit cards
 				</td>
 			</tr>
 			<tr>
 				<td class="rh font-m uc ico-interest">
-                    <div class="icon-positioning-fix">
-    					<div class="icon ico-bullet_plus"></div>
-                    </div>
+					<div class="icon-positioning-fix ico-bullet_plus">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H549.6v213.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V655.9H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h213.6V342.3c0-27.6 22.4-50 50-50s50 22.4 50 50v213.6h213.6c27.6 0 50 22.4 50 50s-22.5 50-50.1 50z"></path></svg>
+					</div>
 					Benefits
 				</td>
 				<td class="line">
-				<p>May waive or reimburse ATM fees, even those for out-of-network ATMs</p>
-
-<p>Often include online banking and bill-pay</p>
-
-<p>Often have mobile apps for things like remote check deposit</p>
-
-<p>Often won't let you overdraft your account</p>
+					<p>May waive or reimburse ATM fees, even those for out-of-network ATMs</p>
+					<p>Often include online banking and bill-pay</p>
+					<p>Often have mobile apps for things like remote check deposit</p>
+					<p>Often won't let you overdraft your account</p>
 				</td>
 				<td class="line">
-				<p>Free access to in-network ATMs</p>
-
-<p>May include online banking and bill-pay</p>
-
-<p>Access to traditional in-person bank branches</p>
+					<p>Free access to in-network ATMs</p>
+					<p>May include online banking and bill-pay</p>
+					<p>Access to traditional in-person bank branches</p>
 				</td>
 				<td class="line">
-				<p>On-campus branch locations and ATMs
-May include online banking and bill-pay</p>
-
-<p>May offer discounts at local or campus businesses</p>
-
-<p>Sometimes your student ID card can be used to access your money</p>
+					<p>On-campus branch locations and ATMs May include online banking and bill-pay</p>
+					<p>May offer discounts at local or campus businesses</p>
+					<p>Sometimes your student ID card can be used to access your money</p>
 				</td>
 			</tr>
 			<tr>
 				<td class="rh font-m uc ico-eligibility">
-                    <div class="icon-positioning-fix">
-					    <div class="icon ico-bullet_minus"></div>
-                    </div>
+					<div class="icon-positioning-fix ico-bullet_minus">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h527.1c27.6 0 50 22.4 50 50s-22.4 50-50 50z"></path></svg>
+					</div>
 					Risks
 				</td>
 				<td class="line">
 				Generally do not have in-person customer service options
 				</td>
 				<td class="line">
-			    <p>Possibly charge monthly maintenance fees - up to $12 a month in some cases - if you don't meet the minimum balance or the bank's other enrollment criteria, like maintaining a full-time enrollment status at school</p>
-
-<p>May charge more than $30 per overdraft, which can add up quickly, especially if you opt in to coverage for ATM and debit card overdrafts</p>
+			    	<p>Possibly charge monthly maintenance fees - up to $12 a month in some cases - if you don't meet the minimum balance or the bank's other enrollment criteria, like maintaining a full-time enrollment status at school</p>
+					<p>May charge more than $30 per overdraft, which can add up quickly, especially if you opt in to coverage for ATM and debit card overdrafts</p>
 				</td>
 				<td class="line">
-				<p>Could charge fees every time you use your debit card</p>
-
-<p>Don't always provide the ability to write checks</p>
-
-<p>May charge inactivity fees each month for not using your account frequently</p>
-
-<p>Possibly charge monthly maintenance fees - up to $12 a month in some cases - if you don't meet the minimum balance or the bank's other enrollment criteria, like maintaining a full-time enrollment status at school</p>
-
-<p>May charge more than $30 per overdraft, which can add up quickly especially if you opt in to coverage for ATM and debit card overdrafts</p>
+					<p>Could charge fees every time you use your debit card</p>
+					<p>Don't always provide the ability to write checks</p>
+					<p>May charge inactivity fees each month for not using your account frequently</p>
+					<p>Possibly charge monthly maintenance fees - up to $12 a month in some cases - if you don't meet the minimum balance or the bank's other enrollment criteria, like maintaining a full-time enrollment status at school</p>
+					<p>May charge more than $30 per overdraft, which can add up quickly especially if you opt in to coverage for ATM and debit card overdrafts</p>
 				</td>
 			</tr>
 			</tbody>
@@ -272,14 +268,22 @@ May include online banking and bill-pay</p>
 <h2 class='comparison-h2'>Financial aid disbursement</h2>
 <div class="row cf vspace2">
     <div class="rel-ico-span relative">
-    	<div class="icon ico-bullet_check"></div>
-		<h4 class="vspace1 offset-s">What you need to know</h4>
-		<p class="offset-s" style='color:#444;'>After your school takes out the cost of tuition, fees, and any on-campus living expenses from your total financial aid award, there is often money left for you to use for other expenses, like books. </p>
+		<h4 class="vspace1 offset-s">
+			<span class="ico-bullet_check">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
+			</span>
+			What you need to know
+		</h4>
+		<p>After your school takes out the cost of tuition, fees, and any on-campus living expenses from your total financial aid award, there is often money left for you to use for other expenses, like books. </p>
 	</div>
 	<div class="rel-ico-span relative">
-		<div class="icon ico-bullet_check"></div>
-		<h4 class="vspace1 offset-s">Keep in mind</h4>
-		<p class="offset-s" style='color:#444;'>You normally have several options for how you get that money, including direct deposit to a bank account, to a card that might also double as your student ID, by check, or cash.</p>
+		<h4 class="vspace1 offset-s">
+			<span class="ico-bullet_check">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
+			</span>
+			Keep in mind
+		</h4>
+		<p>You normally have several options for how you get that money, including direct deposit to a bank account, to a card that might also double as your student ID, by check, or cash.</p>
 	</div>
 </div>
 
@@ -304,63 +308,63 @@ May include online banking and bill-pay</p>
 			<tbody class="">
 			<tr>
 				<td class="rh font-m uc">
-                    <div class="icon-positioning-fix">
-					    <div class="icon ico-bullet_check"></div>
-                    </div>
+					<div class="icon-positioning-fix ico-bullet_check">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
+					</div>
 				    How it works
 				</td>
 			    <td class="thick-line">
-			    Once you choose the best bank account for you, share that information with your school, and they will deposit additional aid funds directly to that account
+			    	Once you choose the best bank account for you, share that information with your school, and they will deposit additional aid funds directly to that account
 			    </td>
 				<td class="thick-line">
-				Schools generally must offer a paper check or cash option no later than 14 days after the funds are available
+					Schools generally must offer a paper check or cash option no later than 14 days after the funds are available
 				</td>
 				<td class="thick-line">
-				<p>A school may partner with a bank or another third party to handle financial aid disbursements</p>
+					<p>A school may partner with a bank or another third party to handle financial aid disbursements</p>
 
-<p>The most common option is a debit card attached to bank account that has your financial aid deposited in it</p>
+					<p>The most common option is a debit card attached to bank account that has your financial aid deposited in it</p>
 
-<p>You are not required to use the bank chosen by your school</p>
+					<p>You are not required to use the bank chosen by your school</p>
 				</td>
 			</tr>
 			<tr>
 				<td class="rh font-m uc ico-interest">
-                    <div class="icon-positioning-fix">
-    					<div class="icon ico-bullet_plus"></div>
-                    </div>
+					<div class="icon-positioning-fix ico-bullet_plus">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H549.6v213.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V655.9H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h213.6V342.3c0-27.6 22.4-50 50-50s50 22.4 50 50v213.6h213.6c27.6 0 50 22.4 50 50s-22.5 50-50.1 50z"></path></svg>
+					</div>
 					Benefits
 				</td>
 				<td class="line">
-				<p>You can pick an account that offers what you need and charges few or no fees</p>
+					<p>You can pick an account that offers what you need and charges few or no fees</p>
 
-<p>You can access the disbursement quickly with direct deposit</p>
+					<p>You can access the disbursement quickly with direct deposit</p>
 				</td>
 				<td class="line">
-				You can deposit your money into the account of your choice and do not need to provide additional personal financial information
+					You can deposit your money into the account of your choice and do not need to provide additional personal financial information
 				</td>
 				<td class="line">
-				Often the quickest way to access to your disbursement if you haven't already provided your school with direct deposit information
+					Often the quickest way to access to your disbursement if you haven't already provided your school with direct deposit information
 				</td>
 			</tr>
 			<tr>
 				<td class="rh font-m uc ico-eligibility">
-                    <div class="icon-positioning-fix">
-					    <div class="icon ico-bullet_minus"></div>
-                    </div>
+					<div class="icon-positioning-fix ico-bullet_minus">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h527.1c27.6 0 50 22.4 50 50s-22.4 50-50 50z"></path></svg>
+					</div>
 					Risks
 				</td>
 				<td class="line">
-				No significant risks
+					No significant risks
 				</td>
 				<td class="line">
-			    <p>If you use a check casher, they may charge as much as 4% of the check amount</p>
+			    	<p>If you use a check casher, they may charge as much as 4% of the check amount</p>
 
-<p>You may not be able to access your funds immediately after making a deposit</p>
+					<p>You may not be able to access your funds immediately after making a deposit</p>
 				</td>
 				<td class="line">
-				<p>The school makes the agreement with the bank, not you</p>
+					<p>The school makes the agreement with the bank, not you</p>
 
-<p>You won't be able to shop for a low-cost product, and these cards and accounts may come with fees you could avoid by shopping</p>
+					<p>You won't be able to shop for a low-cost product, and these cards and accounts may come with fees you could avoid by shopping</p>
 				</td>
 			</tr>
 			</tbody>
@@ -427,8 +431,8 @@ What is a financial aid disbursement? </div>
 		</div>
 		<div class='span3'>
 			<a class="btn btn-document" href="/f/Money.pdf" target="_blank" rel="noopener noreferrer">
-    Download <br>action guide
-</a>
+				Download <br>action guide
+			</a>
 		</div>
 	</div>
 </section>

--- a/comparisontool/templates/comparisontool/repay_student_debt.html
+++ b/comparisontool/templates/comparisontool/repay_student_debt.html
@@ -24,10 +24,6 @@
 
 {% block page_css %}
     <link href="{% static 'repaystudentdebt/css/repay.css' %}" rel="stylesheet">
-    <link rel='stylesheet' id='cfpb_icon_font-css'  href="/wp-content/themes/cfpb_nemo/_/cfpb-icon-font/css/icons.css?ver=all" type="text/css" media="all">
-    <!--[if IE 7]>
-    <link rel="stylesheet" id="cfpb_icon_font_ie7-css"  href="/wp-content/themes/cfpb_nemo/_/cfpb-icon-font/css/icons-ie7.css?ver=all" type="text/css" media="all" />
-    <![endif]-->
 {% endblock %}
 
 {% block jquery %}

--- a/comparisontool/templates/comparisontool/worksheet.html
+++ b/comparisontool/templates/comparisontool/worksheet.html
@@ -26,10 +26,6 @@
 
 {% block page_css %}
 <link rel="stylesheet" href="{% static 'comparisontool/css/comparison-tool.css' %}">
-<link rel='stylesheet' id='cfpb_icon_font-css'  href="{% static 'nemo/_/cfpb-icon-font/css/icons.css' %}" type="text/css" media="all">
-    <!--[if IE 7]>
-    <link rel="stylesheet" id="cfpb_icon_font_ie7-css"  href="{% static 'nemo/_/cfpb-icon-font/css/icons-ie7.css' %}" type="text/css" media="all" />
-    <![endif]-->
 {% endblock %}
 
 {% block jquery %}
@@ -94,7 +90,13 @@ var restoredata = {{ data_js|safe }};
 <div id="pfc-notification-wrapper" class="pfc-notification-wrapper">
     <div id="pfc-notification-bar" class="pfc-notification-bar clearfix">
         <p class="pfc-notification-left">This page works better on a desktop, but you can <a id="pfc-close-text" class="pfc-close-text" href="javascript:void(0)">continue anyway</a>.</p>
-        <p class="pfc-notification-right"><button id="pfc-close-bar" class="pfc-close-bar"><i class="icon-delete"></i><span class="cfpb_visually_hide">Dismiss</span></button></p>
+        <p class="pfc-notification-right">
+            <button id="pfc-close-bar" class="pfc-close-bar">
+                <!-- Includes custom icon-delete class to set color. -->
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 718.9 1200" class="cf-icon-svg icon-delete"><path d="M451.4 613.7l248.1-248.1c25.6-25.1 26-66.3.8-91.9s-66.3-26-91.9-.8l-.8.8-248.1 248.1-248.1-248.1c-25.4-25.4-66.5-25.4-91.9 0s-25.4 66.5 0 91.9l248.1 248.1L19.5 861.8c-25.6 25.1-26 66.3-.8 91.9s66.3 26 91.9.8l.8-.8 248.1-248.1 248.1 248.1c25.4 25.4 66.5 25.4 91.9 0s25.4-66.5 0-91.9L451.4 613.7z"></path></svg>
+                <span class="cfpb_visually_hide">Dismiss</span>
+            </button>
+        </p>
     </div>
 </div>
 {% endblock %}
@@ -104,7 +106,12 @@ var restoredata = {{ data_js|safe }};
         <div id="pfc-hero-wrapper" class="pfc-hero-wrapper clearfix">
             <div class="pfc-hero-content">
                 <div class="breadcrumbs">
-                    <p><i class="icon-left"></i><a href="/paying-for-college/">Paying for College</a></p>
+                    <p>
+                        <a href="/{{url_root}}/">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 559.6 1200" class="cf-icon-svg"><path d="M494.5 1090.7c-17.3 0-33.8-6.8-46-19L19 642.1c-25.4-25.4-25.4-66.5 0-91.9l429.5-429.5c25.6-25.1 66.8-24.8 91.9.8 24.8 25.3 24.8 65.8 0 91.1L156.9 596.2l383.6 383.6c25.4 25.4 25.4 66.5.1 91.9-12.3 12.2-28.8 19-46.1 19z"></path></svg>
+                            Paying for College
+                        </a>
+                    </p>
                 </div>
                 <h1 class="sub-page">Compare financial aid</h1>
                 <p>Compare college costs and financial aid offers to see how they might impact you down the road. Just researching schools? Check out <a class="exit-link" href="http://collegecost.ed.gov/scorecard/index.aspx" target="_blank" rel="noopener noreferrer">College Scorecard</a>.</p>
@@ -987,8 +994,16 @@ var restoredata = {{ data_js|safe }};
     <div class="email-group">
         <button id="send-email" class="button">Email worksheet</button> <span id="send-email-confirm" style="display:none;">Success!</span>
     </div>
-    <p class="time"><i class="icon-approved-alt"></i><span id="timestamp"></span></p>
-    <button id="close-modal"><i class="icon-delete-alt"></i><span class="cfpb_visually_hide">Close modal</span></button>
+    <p class="time">
+        <!-- Note: SVG includes custom icon-approved-alt class. -->
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg icon-approved-alt"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm259 284.2L481.4 870.3c-8.2 14.1-22.7 23.4-39 24.8-1.4.1-2.9.2-4.3.2-14.8 0-28.9-6.6-38.4-18L244.4 690.9c-17.9-21-15.4-52.6 5.7-70.5 21-17.9 52.6-15.4 70.5 5.7.2.3.5.5.7.8l109.4 131.4 241.8-418.8c13.6-24 44.2-32.4 68.2-18.8 24 13.6 32.4 44.2 18.8 68.2l-.5.5z"></path></svg>
+        <span id="timestamp"></span>
+    </p>
+    <button id="close-modal">
+        <!-- Note: SVG includes custom icon-delete-alt class. -->
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg icon-delete-alt"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+        <span class="cfpb_visually_hide">Close modal</span>
+    </button>
 </div><!-- end #modal -->
 <div id="modal-overlay" tabindex="-1"></div>
 {% endblock %}


### PR DESCRIPTION
## Additions
- Add issue and pull request templates.

## Removals
- Remove `cfpb_icon_font` CSS references.

## Changes
- Convert round numbered list image icons to pure CSS.
- Convert round check, plus, and minus icons to SVG icons.
- Convert share icons to SVG.
- Add padding to paragraph that was missing it on the landing page (see screenshot).

## Testing
- With this repo and branch cloned into a sibling directory to cfgov-refresh, run `pip install -e ../django-college-costs-comparison`
- Visit /paying-for-college/ URLs and compare to production. There are still some image icons, but some should be converted to SVG or pure CSS.

## Screenshots

Before:
<img width="384" alt="Screen Shot 2019-06-12 at 11 26 59 AM" src="https://user-images.githubusercontent.com/704760/59379932-f11c9780-8d25-11e9-9d2b-399cb12f36e3.png">

After:
<img width="391" alt="Screen Shot 2019-06-12 at 11 26 50 AM" src="https://user-images.githubusercontent.com/704760/59379937-f4b01e80-8d25-11e9-849e-982cea9cb6ee.png">

Before:
<img width="239" alt="Screen Shot 2019-06-12 at 3 23 31 PM" src="https://user-images.githubusercontent.com/704760/59379989-14dfdd80-8d26-11e9-8af0-7290df2f1bfe.png">

After:
<img width="245" alt="Screen Shot 2019-06-12 at 3 23 17 PM" src="https://user-images.githubusercontent.com/704760/59379992-17dace00-8d26-11e9-8425-9e46b3b98a59.png">

Before:
<img width="378" alt="Screen Shot 2019-06-12 at 3 23 26 PM" src="https://user-images.githubusercontent.com/704760/59380016-232df980-8d26-11e9-9e43-0c1bb67fe0fb.png">

After:
<img width="373" alt="Screen Shot 2019-06-12 at 3 24 56 PM" src="https://user-images.githubusercontent.com/704760/59380071-448ee580-8d26-11e9-8f04-24ec24dcdd5c.png">

Before:
<img width="996" alt="Screen Shot 2019-06-12 at 3 34 39 PM" src="https://user-images.githubusercontent.com/704760/59380681-a4d25700-8d27-11e9-86f6-4c1b14ba5b8b.png">

After:
<img width="997" alt="Screen Shot 2019-06-12 at 3 34 54 PM" src="https://user-images.githubusercontent.com/704760/59380691-a865de00-8d27-11e9-82c4-410ddb1e4a14.png">



## Notes
- I didn't convert image icons that are not in the SVG icon set and these icons are now positioned differently from production, however, they are left-aligned with no padding on production, so this is perhaps slightly better.

<img width="685" alt="Screen Shot 2019-06-12 at 3 22 07 PM" src="https://user-images.githubusercontent.com/704760/59379906-dcd89a80-8d25-11e9-8c0e-f61c776f538c.png">
