### PR TITLE
Generate a universal wheel to support Python 2/3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 before_script: psql -c 'create database dccc;' -U postgres
 script:
 - tox
-- python setup.py bdist_wheel
+- python setup.py bdist_wheel --universal
 
 deploy:
   provider: releases


### PR DESCRIPTION
We want to generate a universal wheel that can be installed with both Python 2 and 3.

## Testing

Observe that Travis builds a universal wheel.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

