### PR TITLE
Restore storage of worksheet data

### DIFF
--- a/comparisontool/tests/test_views.py
+++ b/comparisontool/tests/test_views.py
@@ -1,9 +1,9 @@
 import json
 import uuid
 
-import django
 from django.core import mail
 from django.test import RequestFactory, TestCase
+from django.urls import reverse
 from django.utils.encoding import force_text
 
 from comparisontool.models import BAHRate, School, Worksheet
@@ -13,11 +13,6 @@ from comparisontool.views import (
     bah_lookup_api,
     school_search_api,
 )
-
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
 
 
 class BAHLookupAPITests(TestCase):
@@ -109,13 +104,11 @@ class DataStorageViewTests(TestCase):
             }),
             content_type='application/json'
         )
-
         self.worksheet.refresh_from_db()
-        if django.VERSION < (2, 0):
-            self.assertEqual(
-                json.loads(self.worksheet.saved_data)['1'],
-                saved_data_json
-            )
+        self.assertEqual(
+            json.loads(self.worksheet.saved_data)['1'],
+            saved_data_json
+        )
 
     def test_post_with_invalid_field_raises_error(self):
         with self.assertRaises(WorksheetJsonValidationError):
@@ -174,15 +167,10 @@ class SchoolRepresentationTests(TestCase):
     def test_valid_school_returns_school_data_json(self):
         school = School.objects.create(
             school_id=123,
-            data_json=b'{"foo": "bar"}'
+            data_json=json.dumps({"foo": "bar"})
         )
-
         response = self.client.get(self.path(school_id=123))
-        if django.VERSION < (2, 0):
-            self.assertEqual(response.content, school.data_json)
-        else:
-            school_data_json = b'b\'{"foo": "bar"}\''
-            self.assertEqual(response.content, school_data_json)
+        self.assertEqual(response.content, school.data_json.encode('utf-8'))
 
 
 class SchoolSearchAPITests(TestCase):

--- a/comparisontool/urls.py
+++ b/comparisontool/urls.py
@@ -1,3 +1,4 @@
+from django.urls import re_path
 from django.views.generic import TemplateView
 
 from comparisontool.views import (
@@ -9,12 +10,6 @@ from comparisontool.views import (
     bah_lookup_api,
     school_search_api,
 )
-
-try:
-    from django.urls import re_path
-except ImportError:
-    from django.conf.urls import url as re_path
-
 
 urlpatterns = [
     re_path(

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 usedevelop=True
-envlist=lint,py{36}-dj{111,22}-{sqlite,postgres}
+envlist=lint,py{36}-dj{22}-{postgres}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -16,13 +16,11 @@ basepython=
 
 deps=
     coverage==4.2
-    dj111: Django>=1.11,<1.12
     dj22: Django>=2.2,<2.3
     postgres: psycopg2>=2.7
 
 setenv=
     postgres: DATABASE_URL=postgres://localhost/dccc
-    sqlite: DATABASE_URL=sqlite:///:memory:
 
 [testenv:lint]
 # Invoke with: tox -e lint


### PR DESCRIPTION
After we upgraded to Django 2.2 on May 18, the paying-for-college comparisontool
stopped saving worksheet json data properly. Because of the way Django
handles request body encoding, we need to decode content from a POST request
before saving it to the database.

## Testing
You can skip steps 1 and 2 if you wait for the PR Docker instance to spin up.

1. If testing locally, make sure you have Elasticsearch running, natively or in Docker, and make sure comparisontool data are indexed. You can index with this command:
```bash
./cfgov/manage.py update_index comparisontool
```
2. Visit the comparison page:
<http://localhost:8000/paying-for-college/compare-financial-aid-and-college-cost/>  
3. Click "Get started" and follow the steps for picking up to 3 schools to compare.
To be able to pick schools, you'll need to have Elasticsearch running with a populated index.
If you haven't indexed the comparisontool data locally, you can do that with a manage.py command:
4. After choosing your school(s), click "Continue" near the top right of the page.
5. Click the "Save your work" button

You should get an email dialog. Rather than attempting to email it (which will print it
to console in your runserver tab), copy the URL field from the email dialog.

Open a new browser tab, paste in the URL, and remove the "s" from "https" prefix.

Your request should return the restored worksheet, which proves the json data
made the round trip from your initial browser tab to the cfgov database and back.

Currently, if you try this routine on www.consumerfinance.gov,
you will encounter a server error when saving the worksheet.

Tox note: Since we've moved to Django 2, I removed Django 1.11 from the tox matrix, and conditional code for running and testing in Django 1.1.
