### PR TITLE
Update jQuery to 3.5.1

### DIFF
--- a/comparisontool/static/comparisontool/test/SpecRunner.html
+++ b/comparisontool/static/comparisontool/test/SpecRunner.html
@@ -6,7 +6,7 @@
 
   <link rel="shortcut icon" type="image/png" href="lib/jasmine-1.3.0/jasmine_favicon.png">
   <link rel="stylesheet" type="text/css" href="lib/jasmine-1.3.0/jasmine.css">
-  <script type="text/javascript" src="js/jquery-1.9.1.min.js"></script>
+  <script type="text/javascript" src="js/jquery-3.5.1.min.js"></script>
   <script type="text/javascript" src="lib/jasmine-1.3.0/jasmine.js"></script>
   <script type="text/javascript" src="lib/jasmine-1.3.0/jasmine-html.js"></script>
   <script type="text/javascript" src="lib/jasmine-jquery.js"></script>

--- a/comparisontool/templates/comparisontool/choose_a_loan.html
+++ b/comparisontool/templates/comparisontool/choose_a_loan.html
@@ -585,7 +585,7 @@
 {% endblock %}
 
 {% block jquery %}
-<script src="{% static 'nemo/_/js/jquery-1.9.1.min.js' %}"></script>
+<script src="{% static 'agreements/js/jquery-3.5.1.min.js' %}"></script>
 {% endblock %}
 
 {% block page_js %}

--- a/comparisontool/templates/comparisontool/manage_your_money.html
+++ b/comparisontool/templates/comparisontool/manage_your_money.html
@@ -22,7 +22,7 @@
 {% endblock %}
 
 {% block jquery %}
-<script src="{% static 'nemo/_/js/jquery-1.9.1.min.js' %}"></script>
+<script src="{% static 'agreements/js/jquery-3.5.1.min.js' %}"></script>
 {% endblock %}
 
 {% block body_class %}page paying-for-college{% endblock %}

--- a/comparisontool/templates/comparisontool/repay_student_debt.html
+++ b/comparisontool/templates/comparisontool/repay_student_debt.html
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block jquery %}
-<script src="{% static 'nemo/_/js/jquery-1.9.1.min.js' %}"></script>
+<script src="{% static 'agreements/js/jquery-3.5.1.min.js' %}"></script>
 {% endblock %}
 
 {% block analytics_js %}

--- a/comparisontool/templates/comparisontool/worksheet.html
+++ b/comparisontool/templates/comparisontool/worksheet.html
@@ -29,7 +29,7 @@
 {% endblock %}
 
 {% block jquery %}
-<script src="{% static 'nemo/_/js/jquery-1.9.1.min.js' %}"></script>
+<script src="{% static 'agreements/js/jquery-3.5.1.min.js' %}"></script>
 {% endblock %}
 
 {% block page_js %}


### PR DESCRIPTION
jQuery 1.9.1 was updated to 3.5.1 in the consumerfinance.gov repo.

## Changes

- Updates references to jQuery from 1.9.1 to 3.5.1 to match the updates in https://github.com/cfpb/consumerfinance.gov/pull/6020

## Testing

1. Pull branch
1. Install in your local environtment
1. Visit these pages locally and confirm that the fancy stuff works as expected:
  - http://localhost:8000/paying-for-college/manage-your-college-money/
  - http://localhost:8000/paying-for-college/choose-a-student-loan/
  - http://localhost:8000/paying-for-college/repay-student-debt/

## Todos

- Oh, you know…

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

